### PR TITLE
Strict col types for `screenmill-plates.csv` and use dir

### DIFF
--- a/man/annotate_plates.Rd
+++ b/man/annotate_plates.Rd
@@ -11,7 +11,7 @@ annotate_plates(dir = NULL, queries = getOption("screenmill.queries"),
   30, 33, 37), overwrite = FALSE)
 }
 \arguments{
-\item{dir}{The directory containing images to annotate. If \code{NULL} the
+\item{dir}{Directory of images to process. If \code{NULL} the
 user will be prompted to choose a directory.}
 
 \item{queries}{A vector, or dataframe of available queries. Uses

--- a/man/calibrate_crop.Rd
+++ b/man/calibrate_crop.Rd
@@ -4,13 +4,12 @@
 \alias{calibrate_crop}
 \title{Calibrate cropping and rotation parameters}
 \usage{
-calibrate_crop(annotations, rotate = 90, range = 6, step = 0.2,
-  thresh = 0.03, invert = TRUE, rough_pad = c(0, 0, 0, 0),
-  fine_pad = c(5, 5, 5, 5), display = TRUE, overwrite = FALSE)
+calibrate_crop(dir, rotate = 90, range = 6, step = 0.2, thresh = 0.03,
+  invert = TRUE, rough_pad = c(0, 0, 0, 0), fine_pad = c(5, 5, 5, 5),
+  display = TRUE, overwrite = FALSE)
 }
 \arguments{
-\item{annotations}{Path to a screenmill plates annotation CSV file
-(the result of \link{annotate_plates}).}
+\item{dir}{Directory of images to process.}
 
 \item{rotate}{A rough angle in degrees clockwise to rotate each plate. The
 rotation angle will be further calibrated after applying this rotation.
@@ -33,10 +32,6 @@ Defaults to \code{TRUE}.}
 
 \item{overwrite}{Should an existing screenmill plate annotation file be
 overwritten? Defaults to \code{FALSE}.}
-}
-\value{
-Writes a file called \code{screenmill-plate-annotations.csv} to the image
-directory and returns a path to this file.
 }
 \description{
 This function calibrates plate cropping and rotation parameters for an image

--- a/man/calibrate_crop.Rd
+++ b/man/calibrate_crop.Rd
@@ -4,12 +4,12 @@
 \alias{calibrate_crop}
 \title{Calibrate cropping and rotation parameters}
 \usage{
-calibrate_crop(screenmill_plates, rotate = 90, range = 6, step = 0.2,
+calibrate_crop(annotations, rotate = 90, range = 6, step = 0.2,
   thresh = 0.03, invert = TRUE, rough_pad = c(0, 0, 0, 0),
   fine_pad = c(5, 5, 5, 5), display = TRUE, overwrite = FALSE)
 }
 \arguments{
-\item{screenmill_plates}{Path to a screenmill plates annotation CSV file
+\item{annotations}{Path to a screenmill plates annotation CSV file
 (the result of \link{annotate_plates}).}
 
 \item{rotate}{A rough angle in degrees clockwise to rotate each plate. The


### PR DESCRIPTION
- `screenmill_plates` internal function added to enforce column types.
- `annotate_plates` and `calibrate_crop` now use and return the directory path instead of a path to `screenmill-plates.csv`.
