### PR TITLE
No compression when writing tiff images

### DIFF
--- a/R/cm-crop.R
+++ b/R/cm-crop.R
@@ -72,7 +72,7 @@ crop <- function(dir, target = 'cropped', overwrite = FALSE) {
       rough   <- with(coords, img[ left[p]:right[p], top[p]:bot[p] ])
       rotated <- rotate(rough, coords$rotate[p])
       fine    <- with(coords, rotated[ fine_left[p]:fine_right[p], fine_top[p]:fine_bot[p] ])
-      EBImage::writeImage(fine, paste0(dir, '/', coords$img_crop[p]), type = 'tiff')
+      EBImage::writeImage(fine, paste0(dir, '/', coords$img_crop[p]), type = 'tiff', compression = 'none')
     })
     progress$tick()$print()
   }


### PR DESCRIPTION
LZW was saving cropped plates images with very different file sizes (1.1 MB vs. 2.2 MB) even though they had roughly the same dimensions. This appears to break the original CM-engine. This pull request turns off the default `LZW` compression for writing `tiff` images in `EBImage::writeImage`.
