### PR TITLE
Explicitly save as 8 bit tiff

### DIFF
--- a/R/cm-crop.R
+++ b/R/cm-crop.R
@@ -72,7 +72,13 @@ crop <- function(dir, target = 'cropped', overwrite = FALSE) {
       rough   <- with(coords, img[ left[p]:right[p], top[p]:bot[p] ])
       rotated <- rotate(rough, coords$rotate[p])
       fine    <- with(coords, rotated[ fine_left[p]:fine_right[p], fine_top[p]:fine_bot[p] ])
-      EBImage::writeImage(fine, paste0(dir, '/', coords$img_crop[p]), type = 'tiff', compression = 'none')
+      EBImage::writeImage(
+        fine,
+        paste0(dir, '/', coords$img_crop[p]),
+        type = 'tiff',
+        compression = 'none',
+        bits.per.sample = 8L
+      )
     })
     progress$tick()$print()
   }


### PR DESCRIPTION
`EBImage` appears to have a bug where writing to tiff was switching between 16 bit and 8 bit for no apparent reason. Explicitly setting `bits.per.sample` seems to fix this.
