### PR TITLE
Modification to annotate interface

### DIFF
--- a/R/measure.R
+++ b/R/measure.R
@@ -48,9 +48,12 @@ measure <- function(dir, overwrite = F, save.plates = F, save.colonies = 'rds') 
   time <- Sys.time()
 
   # For each image
+  message('Measuring ', length(paths), ' images')
+  progress <- progress_estimated(length(paths))
   cores <- ifelse(.Platform$OS.type == 'windows', 1, max(1, detectCores(), na.rm = T))
   lapply(paths, function(pth) {
 
+    progress$tick()$print()
     img <- read_greyscale(pth)
     coords <- filter(plates, path == pth)
     plate_ids <- unique(coords$plate_id)

--- a/man/annotate.Rd
+++ b/man/annotate.Rd
@@ -6,6 +6,8 @@
 \usage{
 annotate(dir = NULL, queries = getOption("screenmill.queries"),
   strain_collections = getOption("screenmill.strain_collections"),
+  strain_collection_keys = getOption("screenmill.strain_collection_keys"),
+  strains = getOption("screenmill.strains"),
   media = getOption("screenmill.media"),
   treatments = getOption("screenmill.treatments"), temperatures = c(23, 27,
   30, 33, 37), overwrite = FALSE)
@@ -14,17 +16,17 @@ annotate(dir = NULL, queries = getOption("screenmill.queries"),
 \item{dir}{Directory of images to process. If \code{NULL} the
 user will be prompted to choose a directory.}
 
-\item{queries}{A vector, or dataframe of available queries. Uses
+\item{queries}{A dataframe of available queries. Uses
 \code{getOption('screenmill.queries')} by default (see Details).}
 
-\item{strain_collections}{A vector, or dataframe of available strain
+\item{strain_collections}{A dataframe of available strain
 collections. Uses \code{getOption('screenmill.strain_collections')}
 (see Details).}
 
-\item{media}{A vector, or dataframe of available media. Uses
+\item{media}{A dataframe of available media. Uses
 \code{getOption('screenmill.media')} by default(see Details).}
 
-\item{treatments}{A vector or dataframe of available treatments. Uses
+\item{treatments}{A dataframe of available treatments. Uses
 \code{getOption('screenmill.treatments')} by default (see Details).}
 
 \item{temperatures}{A vector of recommended temperatures.}


### PR DESCRIPTION
Annotate previously accepted vector input for several annotation tables. This pull request now requires that these are tables and issues warnings if the tables are missing certain columns. After annotation, subsets of these source tables are saved to the project directory.

This setup ensures that each batch can stand alone without depending on external annotation tables. The downside is that annotation data will be duplicated. The solution here is that the data processing script can point to external files and overwrite local copies to keep everything in sync with a central database simply by re-processing.
