### PR TITLE
Add ability to update without overwriting manual annotations

### DIFF
--- a/man/annotate.Rd
+++ b/man/annotate.Rd
@@ -10,7 +10,7 @@ annotate(dir = NULL, queries = getOption("screenmill.queries"),
   strains = getOption("screenmill.strains"),
   media = getOption("screenmill.media"),
   treatments = getOption("screenmill.treatments"), temperatures = c(23, 27,
-  30, 33, 37), overwrite = FALSE)
+  30, 33, 37), overwrite = FALSE, update = TRUE)
 }
 \arguments{
 \item{dir}{Directory of images to process. If \code{NULL} the


### PR DESCRIPTION
This pull request adds an `update` argument to `annotate` which, if `!overwrite` and `screenmill-annotations.csv` is complete, `update` will sync the project's annotation tables with a central annotation database without launching the interactive annotation application.
