### PR TITLE
Background subtraction for every plate, and compute hours of growth

### DIFF
--- a/R/annotate.R
+++ b/R/annotate.R
@@ -380,7 +380,8 @@ annotate <- function(dir, queries, strain_collections, strain_collection_keys,
           date = as.Date(start),
           owner = ifelse(is.null(input$user) || (input$user) == '', NA, (input$user)),
           email = ifelse(is.null(input$email) || (input$user) == '', NA, (input$email)),
-          time_series = (input$ts)
+          time_series = (input$ts),
+          hours_growth = difftime(end, start, units = 'hours') %>% as.numeric
         ) %>%
         group_by(date, group, position) %>%
         # Create plate_id column
@@ -392,7 +393,7 @@ annotate <- function(dir, queries, strain_collections, strain_collection_keys,
           plate_id = paste(date, grp3, pos3, tim3, sep = '-')
         ) %>%
         select(
-          plate_id, date, group, position, timepoint, file, template,
+          plate_id, date, group, position, timepoint, hours_growth, file, template,
           strain_collection_id, plate, query_id, treatment_id, media_id,
           temperature, time_series, start, end = time, owner, email
         )
@@ -403,7 +404,7 @@ annotate <- function(dir, queries, strain_collections, strain_collection_keys,
 
       strain_collections %>%
         filter(strain_collection_id %in% c('', annotations$strain_collection_id)) %>%
-        write_csv(file.path(dir, 'screenmill-collections.csv'))
+        write_csv(file.path(dir, 'screenmill-collections.csv', fsep = '/'))
 
       queries %>%
         filter(query_id %in% c('', annotations$query_id)) %>%
@@ -524,10 +525,10 @@ annotate <- function(dir, queries, strain_collections, strain_collection_keys,
           'The following tables are provided for convenience, if all fields have
           been filled in the above tables, you may press save to exit this
           application:')),
-        h2(tags$small('Strain collections')),
-        dataTableOutput('strain_collections'),
         h2(tags$small('Queries')),
         dataTableOutput('queries'),
+        h2(tags$small('Strain collections')),
+        dataTableOutput('strain_collections'),
         h2(tags$small('Treatments')),
         dataTableOutput('treatments'),
         h2(tags$small('Media')),

--- a/R/calibrate.R
+++ b/R/calibrate.R
@@ -244,7 +244,7 @@ calibrate_template <- function(template, annotation, key, thresh, invert, rough_
             left_join(row_df, by = c('colony_row', 'colony_col')) %>%
             left_join(col_df, by = c('colony_row', 'colony_col')) %>%
             left_join(rep_df, by = c('colony_row', 'colony_col')) %>%
-            select(template:replicate, colony_row:background, everything())
+            select(template:replicate, colony_row:b, everything())
         }
       }
 
@@ -373,21 +373,10 @@ locate_grid <- function(img, radius = 0.9) {
       l = as.integer(round(ifelse(l < 1, 1, l))),
       r = as.integer(round(ifelse(r > nrow(img), nrow(img), r))),
       t = as.integer(round(ifelse(t < 1, 1, t))),
-      b = as.integer(round(ifelse(b > ncol(img), ncol(img), b))),
-      # Identify corner intensities,
-      tl = img[as.matrix(cbind(l, t))],
-      tr = img[as.matrix(cbind(r, t))],
-      bl = img[as.matrix(cbind(l, b))],
-      br = img[as.matrix(cbind(r, b))],
-      bg = apply(cbind(tl, tr, bl, br), 1, mean, trim = 0.5)
+      b = as.integer(round(ifelse(b > ncol(img), ncol(img), b)))
     )
 
-  # Predict background intensity via loess smoothing
-  selection$background <-
-    loess(bg ~ colony_row + colony_col, data = selection, span = 0.3, normalize = F, degree = 2) %>%
-    predict
-
-  return(selection %>% select(colony_row, colony_col, x, y, l, r, t, b, background))
+  return(selection %>% select(colony_row, colony_col, x, y, l, r, t, b))
 }
 
 # ---- Display Calibration: TODO ----------------------------------------------


### PR DESCRIPTION
`calibrate` and `measure`: Background subtraction is now computed during `measure` for every plate at every time-point.

`annotate`: A new column, `hours_growth` is now computed from `start` and `end` when annotating plates.
